### PR TITLE
feat: Refine booking system and plan new features

### DIFF
--- a/supabase.sql
+++ b/supabase.sql
@@ -28,7 +28,8 @@ create table if not exists public.rsvps (
   court_lga text,
   starts_at timestamptz not null,
   ends_at timestamptz not null,
-  created_at timestamptz default now()
+  created_at timestamptz default now(),
+  unique(user_id, court_id, starts_at)
 );
 
 alter table public.rsvps enable row level security;


### PR DESCRIPTION
This commit introduces several refinements to the RSVP system and provides a detailed plan for future community features.

- **30-Minute Booking Slots:**
  - The booking system has been updated to use 30-minute time slots instead of 1-hour slots.
  - The RSVP form now displays 48 half-hour increments for users to choose from.

- **Unique RSVP Enforcement:**
  - Users are now prevented from booking the same time slot at the same court more than once.
  - This is enforced at the database level with a `UNIQUE` constraint on the `rsvps` table.
  - The frontend has also been updated to disable the RSVP button and inform the user if they have already booked the selected slot.

- **Planning for Future Features:**
  - A detailed plan has been created for the future implementation of picture sharing and live chat functionalities. This plan outlines the necessary database schema changes and the required frontend components.