### PR TITLE
fix: Increase memory limit for Next.js build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "NODE_OPTIONS='--max-old-space-size=4096' next build",
     "start": "next start",
     "lint": "next lint"
   },


### PR DESCRIPTION
This commit addresses a build failure on Vercel that appears to be caused by the Node.js process running out of memory.

The `build` script in `package.json` has been modified to include the `NODE_OPTIONS='--max-old-space-size=4096'` flag. This increases the maximum heap size for the Node.js process to 4GB, which should be sufficient to allow the `next build` command to complete successfully in Vercel's build environment.