### PR TITLE
fix: Resolve `window is not defined` build error

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -1,8 +1,13 @@
 'use client'
 import { useState, useEffect } from 'react'
-import MapView from '@/components/MapView'
+import dynamic from 'next/dynamic'
 import Rsvp from '@/components/Rsvp'
 import Checkin from '@/components/Checkin'
+
+const MapView = dynamic(() => import('@/components/MapView'), {
+  ssr: false,
+  loading: () => <div className="map-wrap"><p style={{textAlign: 'center', paddingTop: 20}}>Loading map...</p></div>
+})
 
 export default function Page() {
   const [data, setData] = useState({ type: 'FeatureCollection', features: [] })


### PR DESCRIPTION
This commit fixes a `ReferenceError: window is not defined` error that occurred during the Vercel build process.

The error was caused by the `MapView` component, which uses the browser-only Leaflet library, being executed on the server during static page generation.

The fix involves dynamically importing the `MapView` component in `app/page.js` using `next/dynamic` with the `ssr: false` option. This ensures that the component and its dependencies are only loaded and rendered on the client-side, preventing the error during the server-side build.