### PR TITLE
Fix Supabase module resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .pnp.*
+# Allow tracked library files in root lib directory
+!/lib/
+!/lib/**
+# Next.js build output
+/.next/

--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -1,0 +1,8 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+
+export default supabase

--- a/lib/supabaseClient.js
+++ b/lib/supabaseClient.js
@@ -1,0 +1,9 @@
+import { createClient as createSupabaseClient } from '@supabase/supabase-js'
+
+export const createClient = () => {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  return createSupabaseClient(supabaseUrl, supabaseAnonKey)
+}
+
+export default createClient


### PR DESCRIPTION
## Summary
- add Supabase client utilities for browser and server usage
- ensure lib directory is included in repo and ignore Next.js build output

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689aa3c47c8c832bb8c5e3135eb6eb19