### PR TITLE
Optimize marker lookup and improve geolocation handling

### DIFF
--- a/components/Checkin.js
+++ b/components/Checkin.js
@@ -77,6 +77,12 @@ export default function Checkin({ court, rsvps }) {
     setLoading(true)
     setError(null)
 
+    if (!navigator.geolocation) {
+      setError('Geolocation not available in this browser.')
+      setLoading(false)
+      return
+    }
+
     navigator.geolocation.getCurrentPosition(
       async (pos) => {
         const { latitude, longitude, accuracy } = pos.coords

--- a/components/MapView.js
+++ b/components/MapView.js
@@ -107,12 +107,15 @@ function rebuildMarkers(cluster, geojson, onSelect, activeCourtIds) {
   cluster.clearLayers()
   const feats = geojson?.features || []
 
+  // Use a Set for O(1) lookups when checking active courts.
+  const activeIdSet = new Set(activeCourtIds || [])
+
   for (const f of feats) {
     if (f?.geometry?.type !== 'Point') continue
     const [lon, lat] = f.geometry.coordinates
     const p = f.properties || {}
 
-    const isActive = activeCourtIds?.includes(p.id)
+    const isActive = activeIdSet.has(p.id)
     const icon = L.divIcon({
       className: `hnm-dot ${isActive ? 'active' : ''}`,
       html: '',


### PR DESCRIPTION
## Summary
- use a Set for active court lookups to speed up marker rendering
- handle browsers without geolocation to avoid runtime errors

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689aafa081b8832b91d7969ed648637d