### PR TITLE
feat/ux-hardening-rsvps-checkins

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ npm i
 npm run dev
 ```
 
+Optional tests:
+
+```
+npx playwright install
+npx playwright test
+```
+
 Open http://localhost:3000
 
 ## Features

--- a/app/api/checkins/route.ts
+++ b/app/api/checkins/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { cookies } from 'next/headers';
+import { createClient } from '@/lib/supabaseClient';
+import { haversine } from '@/lib/haversine';
+
+const Body = z.object({
+  courtId: z.string().min(1),
+  courtName: z.string().min(1),
+  courtLat: z.number(),
+  courtLon: z.number(),
+  lat: z.number(),
+  lon: z.number(),
+  accuracy: z.number().optional(),
+  source: z.enum(['gps', 'map_center']),
+});
+
+function getUserIdFromCookies(): string | null {
+  return cookies().get('uid')?.value ?? null;
+}
+
+export async function POST(req: Request) {
+  const raw = await req.json();
+  const parse = Body.safeParse(raw);
+  if (!parse.success) return NextResponse.json({ ok:false, error:'invalid body' }, { status:400 });
+
+  const uid = getUserIdFromCookies();
+  if (!uid) return NextResponse.json({ ok:false, error:'no user id' }, { status:401 });
+
+  const { courtId, courtName, courtLat, courtLon, lat, lon, accuracy, source } = parse.data;
+
+  const dist = haversine(lat, lon, courtLat, courtLon);
+  if (dist > 500) {
+    return NextResponse.json({ ok:false, error:'too far', dist }, { status:400 });
+  }
+
+  const supa = createClient();
+  await supa.from('checkins').insert({
+    user_id: uid,
+    court_id: courtId,
+    court_name: courtName,
+    lat,
+    lon,
+    accuracy,
+    source,
+    expires_at: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
+  });
+
+  const since = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+  const { data } = await supa
+    .from('checkins')
+    .select('*')
+    .eq('court_id', courtId)
+    .gte('checked_in_at', since)
+    .order('checked_in_at', { ascending: false });
+
+  return NextResponse.json({ ok:true, checkins: data, dist });
+}

--- a/app/api/rsvps/route.ts
+++ b/app/api/rsvps/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { cookies } from 'next/headers';
+import { createClient } from '@/lib/supabaseClient';
+
+const Body = z.object({
+  courtId: z.string().min(1),
+  courtName: z.string().min(1),
+  startsAt: z.string().transform(v => new Date(v)),
+  email: z.string().email().optional(),
+  name: z.string().optional(),
+});
+
+function getUserIdFromCookies(): string | null {
+  return cookies().get('uid')?.value ?? null;
+}
+
+// simple per-IP limiter
+const ipHits = new Map<string, { count: number; ts: number }>();
+function checkLimit(ip: string) {
+  const now = Date.now();
+  const entry = ipHits.get(ip);
+  if (entry && now - entry.ts < 60_000) {
+    entry.count++;
+    if (entry.count > 30) return false; // allow 30 req/min
+  } else {
+    ipHits.set(ip, { count: 1, ts: now });
+  }
+  return true;
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const courtId = searchParams.get('courtId') ?? '';
+  const startsAt = searchParams.get('startsAt') ?? '';
+  if (!courtId || !startsAt) return NextResponse.json({ ok:false, error:'missing params' }, { status:400 });
+
+  const supa = createClient();
+  const { count, error } = await supa
+    .from('rsvps')
+    .select('id', { count: 'exact', head: true })
+    .eq('court_id', courtId)
+    .eq('starts_at', new Date(startsAt).toISOString());
+  if (error) return NextResponse.json({ ok:false, error:error.message }, { status:500 });
+  return NextResponse.json({ ok:true, count });
+}
+
+export async function POST(req: Request) {
+  const ip = req.headers.get('x-forwarded-for') || 'local';
+  if (!checkLimit(ip)) return NextResponse.json({ ok:false, error:'rate limit' }, { status:429 });
+  const raw = await req.json();
+  const parse = Body.safeParse(raw);
+  if (!parse.success) return NextResponse.json({ ok:false, error:'invalid body' }, { status:400 });
+
+  const uid = getUserIdFromCookies();
+  if (!uid) return NextResponse.json({ ok:false, error:'no user id' }, { status:401 });
+
+  const { courtId, courtName, startsAt, email, name } = parse.data;
+
+  const supa = createClient();
+  const { data, error } = await supa
+    .from('rsvps')
+    .upsert({
+      user_id: uid,
+      court_id: courtId,
+      court_name: courtName,
+      starts_at: new Date(startsAt).toISOString(),
+      email: email ?? null,
+      name: name ?? null,
+    }, { onConflict: 'user_id,court_id,starts_at' })
+    .select()
+    .single();
+
+  if (error) return NextResponse.json({ ok:false, error:error.message }, { status:500 });
+
+  const { count } = await supa
+    .from('rsvps')
+    .select('id', { count: 'exact', head: true })
+    .eq('court_id', courtId)
+    .eq('starts_at', new Date(startsAt).toISOString());
+
+  return NextResponse.json({ ok:true, rsvp: data, count, created: true });
+}
+
+export async function DELETE(req: Request) {
+  const ip = req.headers.get('x-forwarded-for') || 'local';
+  if (!checkLimit(ip)) return NextResponse.json({ ok:false, error:'rate limit' }, { status:429 });
+
+  const { searchParams } = new URL(req.url);
+  const uid = getUserIdFromCookies();
+  if (!uid) return NextResponse.json({ ok:false, error:'no user id' }, { status:401 });
+
+  const courtId = searchParams.get('courtId') ?? '';
+  const startsAt = searchParams.get('startsAt') ?? '';
+  if (!courtId || !startsAt) return NextResponse.json({ ok:false, error:'missing params' }, { status:400 });
+
+  const supa = createClient();
+  const { error } = await supa
+    .from('rsvps')
+    .delete()
+    .eq('user_id', uid)
+    .eq('court_id', courtId)
+    .eq('starts_at', new Date(startsAt).toISOString());
+
+  if (error) return NextResponse.json({ ok:false, error:error.message }, { status:500 });
+  return NextResponse.json({ ok:true });
+}

--- a/app/api/tiles/carto/[z]/[x]/[y]/route.js
+++ b/app/api/tiles/carto/[z]/[x]/[y]/route.js
@@ -11,7 +11,7 @@ export async function GET(_req, { params }) {
   return new Response(r.body, {
     headers: {
       'Content-Type': 'image/png',
-      'Cache-Control': 'public, max-age=31536000, immutable',
+      'Cache-Control': 'public, s-maxage=86400, stale-while-revalidate=604800',
     },
   });
 }

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,6 +1,7 @@
 // app/layout.js
 import './globals.css'   // <-- this is required for styles to load
 import AuthWrapper from '@/components/AuthWrapper'
+import { Toaster } from 'sonner'
 
 export const metadata = {
   title: 'Basketball Courts POC',
@@ -14,6 +15,7 @@ export default function RootLayout({ children }) {
         <AuthWrapper>
           {children}
         </AuthWrapper>
+        <Toaster richColors />
       </body>
     </html>
   )

--- a/components/Checkin.js
+++ b/components/Checkin.js
@@ -4,6 +4,7 @@ import { supabase } from '@/components/supabase'
 import { useSession } from '@/components/AuthWrapper'
 import { formatDistanceToNow } from 'date-fns'
 import { haversine } from '@/lib/haversine'
+import { toast } from 'sonner'
 
 // Check-ins expire after 90 minutes
 const CHECKIN_EXPIRY_MINS = 90
@@ -71,7 +72,7 @@ export default function Checkin({ court, rsvps }) {
 
   const handleCheckin = async () => {
     if (!session) {
-      alert('You must be logged in to check in.')
+      toast.error('You must be logged in to check in.')
       return
     }
     setLoading(true)
@@ -109,14 +110,17 @@ export default function Checkin({ court, rsvps }) {
             expires_at: expires_at.toISOString(),
           })
           if (error) throw error
+          toast.success('Checked in')
         } catch (error) {
           setError(error.message)
+          toast.error(error.message)
         } finally {
           setLoading(false)
         }
       },
       (err) => {
         setError(err.message)
+        toast.error(err.message)
         setLoading(false)
       },
       { enableHighAccuracy: true, timeout: 10000 }

--- a/components/MapView.js
+++ b/components/MapView.js
@@ -4,6 +4,7 @@ import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
 import 'leaflet.markercluster' // provides L.markerClusterGroup
 import { haversine } from '@/lib/haversine'
+import { toast } from 'sonner'
 
 export default function MapView({ data, onSelect, activeCourtIds = [] }) {
   const mapEl = useRef(null)
@@ -171,7 +172,7 @@ function rebuildMarkers(cluster, geojson, onSelect, activeCourtIds) {
 
 function locateAndZoom(map, cluster, nearestLayer, meRef) {
   if (!navigator.geolocation) {
-    alert('Geolocation not available in this browser')
+    toast.error('Geolocation not available in this browser')
     return
   }
   navigator.geolocation.getCurrentPosition(
@@ -204,7 +205,7 @@ function locateAndZoom(map, cluster, nearestLayer, meRef) {
       const bounds = L.latLngBounds([me, ...nearest.map((n) => [n.ll.lat, n.ll.lng])])
       map.fitBounds(bounds, { padding: [40, 40] })
     },
-    (err) => alert(err.message),
+    (err) => toast.error(err.message),
     { enableHighAccuracy: true, timeout: 10000 }
   )
 }

--- a/components/Rsvp.js
+++ b/components/Rsvp.js
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react'
 import { supabase } from '@/components/supabase'
 import { useSession } from '@/components/AuthWrapper'
 import { format } from 'date-fns'
+import { toast } from 'sonner'
 
 export default function Rsvp({ court, rsvps, onRsvpChange }) {
   const { session } = useSession()
@@ -44,7 +45,7 @@ export default function Rsvp({ court, rsvps, onRsvpChange }) {
   const handleRsvp = async (e) => {
     e.preventDefault()
     if (!session) {
-      alert('You must be logged in to RSVP.')
+      toast.error('You must be logged in to RSVP.')
       return
     }
     setLoading(true)
@@ -66,10 +67,10 @@ export default function Rsvp({ court, rsvps, onRsvpChange }) {
         ends_at: ends_at.toISOString(),
       })
       if (error) throw error
-      alert('RSVP successful!')
+      toast.success('RSVP successful')
       onRsvpChange?.()
     } catch (error) {
-      alert(error.error_description || error.message)
+      toast.error(error.error_description || error.message)
     } finally {
       setLoading(false)
     }
@@ -81,8 +82,9 @@ export default function Rsvp({ court, rsvps, onRsvpChange }) {
     const { error } = await supabase.from('rsvps').delete().match({ id: rsvpId })
 
     if (error) {
-      alert(error.message)
+      toast.error(error.message)
     } else {
+      toast.success('RSVP cancelled')
       onRsvpChange?.()
     }
   }

--- a/lib/user.ts
+++ b/lib/user.ts
@@ -1,0 +1,8 @@
+// server: pass NextRequest cookies; client: falls back to localStorage
+export function getClientUserId(): string {
+  const m = document.cookie.match(/(?:^| )uid=([^;]+)/);
+  if (m) return decodeURIComponent(m[1]);
+  let id = localStorage.getItem('uid');
+  if (!id) { id = crypto.randomUUID(); localStorage.setItem('uid', id); }
+  return id;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { randomUUID } from 'crypto';
+
+export function middleware(req: NextRequest) {
+  const res = NextResponse.next();
+  const hasUid = req.cookies.get('uid')?.value;
+  if (!hasUid) {
+    res.cookies.set('uid', randomUUID(), {
+      httpOnly: true,
+      sameSite: 'Lax',
+      secure: true,
+      maxAge: 60 * 60 * 24 * 365,
+      path: '/',
+    });
+  }
+  return res;
+}
+
+export const config = { matcher: ['/', '/(api|app)(.*)'] };

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,11 @@
         "next": "14.2.5",
         "react": "18.3.1",
         "react-dom": "18.3.1",
+        "sonner": "^2.0.7",
         "swr": "^2.2.5"
       },
       "devDependencies": {
+        "@types/react": "19.1.10",
         "eslint": "^8.57.1",
         "eslint-config-next": "14.2.5"
       }
@@ -694,6 +696,16 @@
       "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
       "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
       "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.1.10",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.10.tgz",
+      "integrity": "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/@types/supercluster": {
       "version": "7.1.3",
@@ -1615,6 +1627,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -4875,6 +4894,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -17,9 +17,11 @@
     "next": "14.2.5",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "sonner": "^2.0.7",
     "swr": "^2.2.5"
   },
   "devDependencies": {
+    "@types/react": "19.1.10",
     "eslint": "^8.57.1",
     "eslint-config-next": "14.2.5"
   }

--- a/supabase.sql
+++ b/supabase.sql
@@ -101,3 +101,16 @@ COMMENT ON VIEW public.v_checkins IS 'Public view of active check-ins with displ
 
 -- Advise on setting up realtime
 -- In Supabase dashboard: Database -> Replication -> add tables rsvps, checkins to realtime publication.
+
+-- Added for UX hardening
+-- 1) Ensure RSVP uniqueness (idempotency)
+create unique index if not exists rsvps_unique
+  on public.rsvps (user_id, court_id, starts_at);
+
+-- 2) Optional: relax nullability for email/name (should already be nullable)
+alter table public.rsvps alter column email drop not null;
+alter table public.rsvps alter column name drop not null;
+
+-- 3) Track source of check-in and accuracy (nullable)
+alter table public.checkins add column if not exists source text;
+alter table public.checkins add column if not exists accuracy double precision;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    ".next/types/**/*.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- add anonymous uid cookie middleware and server APIs for RSVPs and check-ins
- switch client alerts to `sonner` toasts and mount global toaster
- cache tile requests for a day and add DB migration for unique RSVPs

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ab27b0198832bbc345976c7630668