### PR TITLE
Fix build by adding path aliases, zod dependency and middleware updates

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,14 +1,13 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
-import { randomUUID } from 'crypto';
 
 export function middleware(req: NextRequest) {
   const res = NextResponse.next();
   const hasUid = req.cookies.get('uid')?.value;
   if (!hasUid) {
-    res.cookies.set('uid', randomUUID(), {
+    res.cookies.set('uid', crypto.randomUUID(), {
       httpOnly: true,
-      sameSite: 'Lax',
+      sameSite: 'lax',
       secure: true,
       maxAge: 60 * 60 * 24 * 365,
       path: '/',

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "sonner": "^2.0.7",
-        "swr": "^2.2.5"
+        "swr": "^2.2.5",
+        "zod": "^3.22.4"
       },
       "devDependencies": {
         "@types/react": "19.1.10",
@@ -5837,6 +5838,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "sonner": "^2.0.7",
-    "swr": "^2.2.5"
+    "swr": "^2.2.5",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/react": "19.1.10",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,13 @@
       {
         "name": "next"
       }
-    ]
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@/app/*": ["app/*"],
+      "@/components/*": ["components/*"],
+      "@/lib/*": ["lib/*"]
+    }
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
## Summary
- configure path aliases in `tsconfig.json` so `@` imports resolve
- add missing `zod` dependency
- update middleware to work in the Edge runtime

## Testing
- `npm run lint`
- `NEXT_PUBLIC_SUPABASE_URL='https://example.com' NEXT_PUBLIC_SUPABASE_ANON_KEY='test' npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ab667cbdc832b9693172acfd5c3bd